### PR TITLE
Improve abstract manipulation of operators

### DIFF
--- a/src/RadiiPolynomial.jl
+++ b/src/RadiiPolynomial.jl
@@ -48,9 +48,10 @@ include("sequence_spaces/sequences/elementary.jl")
 
 
 
-include("sequence_spaces/linear_operators/linear_operator.jl")
-    export LinearOperator, domain, eachcol, eachrow, transpose, adjoint
 import LinearAlgebra: UniformScaling, I
+include("sequence_spaces/linear_operators/linear_operator.jl")
+    export LinearOperator, domain, eachcol, eachrow, transpose, adjoint,
+        Add, Negate, UniformScalingOperator
 include("sequence_spaces/linear_operators/banded_linear_operator.jl")
     export BandedLinearOperator, UniformScaling, I
 include("sequence_spaces/linear_operators/projection.jl")


### PR DESCRIPTION
This PR improves composing `AbstractLinearOperator` before they are materialized by `Projection`.

- New `AbstractLinearOperator` types: `Add`, `Negate` and `UniformScalingOperator`.
- Add a numerical type to `Projection`.

```julia
julia> linop = Laplacian() + Multiplication(Sequence(CosFourier(1, 1.0), [0, 0.5]))
Laplacian() + Multiplication{Sequence{CosFourier{Float64}, Vector{Float64}}}(Sequence(CosFourier(1, 1.0), [0.0, 0.5]))

julia> linop * Projection(CosFourier(3, 1.0))
LinearOperator : CosFourier(3, 1.0) → CosFourier(4, 1.0) with coefficients Matrix{Float64}:
 0.0   1.0   0.0   0.0
 0.5  -1.0   0.5   0.0
 0.0   0.5  -4.0   0.5
 0.0   0.0   0.5  -9.0
 0.0   0.0   0.0   0.5

julia> Derivative(2) * Projection(CosFourier(2, π), Interval{Float64})
LinearOperator : CosFourier(2, π) → CosFourier(2, π) with coefficients Matrix{Interval{Float64}}:
 Interval{Float64}(0.0, 0.0, com, true)  Interval{Float64}(0.0, 0.0, com, true)                                Interval{Float64}(0.0, 0.0, com, true)
 Interval{Float64}(0.0, 0.0, com, true)  Interval{Float64}(-9.869604401089362, -9.869604401089356, com, true)  Interval{Float64}(0.0, 0.0, com, true)
 Interval{Float64}(0.0, 0.0, com, true)  Interval{Float64}(0.0, 0.0, com, true)                                Interval{Float64}(-39.478417604357446, -39.478417604357425, com, true)
```
